### PR TITLE
ユーザー名入力を追加

### DIFF
--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -13,8 +13,6 @@ struct ContentView: View {
         navigator: Navigator()
     )
     
-    @State(initialValue: "quesera2") private var query: String
-
     var body: some View {
         NavigationView {
             List {
@@ -34,7 +32,6 @@ struct ContentView: View {
                 }
             }
         }
-        .searchable(text: $query, prompt: "ユーザー名を入力してください")
         .handleError(
             needShowError: $viewModel.needShowError,
             occursError: viewModel.occursError
@@ -42,6 +39,7 @@ struct ContentView: View {
         .task {
             await viewModel.fetchRepository()
         }
+        .searchable(text: $viewModel.query, prompt: "ユーザー名を入力してください")
     }
 }
 

--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @StateObject private var viewModel = ContentViewModel(
         navigator: Navigator()
     )
+    
+    @State(initialValue: "quesera2") private var query: String
 
     var body: some View {
         NavigationView {
@@ -32,6 +34,7 @@ struct ContentView: View {
                 }
             }
         }
+        .searchable(text: $query, prompt: "ユーザー名を入力してください")
         .handleError(
             needShowError: $viewModel.needShowError,
             occursError: viewModel.occursError

--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -40,6 +40,11 @@ struct ContentView: View {
             await viewModel.fetchRepository()
         }
         .searchable(text: $viewModel.query, prompt: "ユーザー名を入力してください")
+        .onSubmit(of: .search) {
+            Task {
+                await viewModel.fetchRepository()
+            }
+        }
     }
 }
 

--- a/ViewModel/Sources/ViewModel/ContentViewModel.swift
+++ b/ViewModel/Sources/ViewModel/ContentViewModel.swift
@@ -52,6 +52,14 @@ public class ContentViewModel: ObservableObject {
         case .failed(let error):  return error
         }
     }
+    
+    /// 検索するリポジトリ名
+    public var query: String = "quesera2"
+
+    ///  リポジトリ名入力があるかどうか
+    public var isQueryEmpty: Bool {
+        query.isEmpty
+    }
 
     private let apiClient: GitHubAPIClientProtocol
     
@@ -66,9 +74,11 @@ public class ContentViewModel: ObservableObject {
     }
 
     public func fetchRepository() async {
+        guard !self.isQueryEmpty else { return }
+        
         self.state = .loading
         do {
-            let result = try await apiClient.fetchRepositories(userName: "quesera2")
+            let result = try await apiClient.fetchRepositories(userName: self.query)
             self.state = .loaded(result)
         } catch let error as GitHubAPIError {
             switch error {

--- a/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
+++ b/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
@@ -71,6 +71,32 @@ final class ContentViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.occursError)
     }
     
+    func testEmptyInput() async throws {
+        // 入力が空のため何も実行しない
+        let apiClient = MockAPIClient(expectResult: Array(dummyRepositoryData[...0]))
+        let navigator = MockNavigator()
+        let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
+        
+        // 初期状態（エラー、ロード表示なし）
+        XCTAssertEqual(viewModel.repositories, [])
+        XCTAssertFalse(viewModel.showProgress)
+        XCTAssertFalse(viewModel.needShowError)
+        XCTAssertNil(viewModel.occursError)
+        
+        XCTAssertFalse(viewModel.isQueryEmpty)
+        viewModel.query = ""
+        XCTAssertTrue(viewModel.isQueryEmpty)
+        
+        // ロードを実行
+        await viewModel.fetchRepository()
+        
+        // 初期状態と同じであること
+        XCTAssertEqual(viewModel.repositories, [])
+        XCTAssertFalse(viewModel.showProgress)
+        XCTAssertFalse(viewModel.needShowError)
+        XCTAssertNil(viewModel.occursError)
+    }
+    
     func testTransition() {
         // 画面遷移のテスト
         let apiClient = MockAPIClient(expectResult: [])


### PR DESCRIPTION
ユーザー名を入力できるようにして、そのユーザーに紐付いたリポジトリ一覧を返すように機能を追加する

![image](https://user-images.githubusercontent.com/2074276/154947176-f11c2316-3e9f-4a73-a876-94830eb846b7.png)

- 入力内容をStateにしてイベントに含めてVMに送る
- 入力内容をVMと2-way bindingしてVM内から取得する

のどっちがいいのか考え中。前者のほうが素直な気がする