### PR TITLE
リポジトリ検索のキーボード種別を英語に限定

### DIFF
--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -41,12 +41,12 @@ struct ContentView: View {
         .task {
             await viewModel.fetchRepository()
         }
-        .searchable(text: $viewModel.query, prompt: "ユーザー名を入力してください")
-        .onSubmit(of: .search) {
-            Task {
-                await viewModel.fetchRepository()
-            }
-        }
+        .modifier(RepositorySearch(
+            query: viewModel.query,
+            action: {
+                viewModel.fetchRepository()
+            })
+        )
     }
 }
 
@@ -64,6 +64,27 @@ private struct HandleError: ViewModifier {
             }
         )
     }
+}
+
+private struct RepositorySearch: ViewModifier {
+    
+    let query: Binding<String>
+    let action: () async -> Void
+    
+    func body(content: Content) -> some View {
+        content.searchable(
+            text: query,
+            prompt: "ユーザー名を入力してください")
+            .keyboardType(.alphabet)
+            .disableAutocorrection(true)
+            .autocapitalization(.none)            
+            .onSubmit(of: .search) {
+                Task {
+                    await self.action()
+                }
+            }
+    }
+    
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -32,9 +32,11 @@ struct ContentView: View {
                 }
             }
         }
-        .handleError(
-            needShowError: $viewModel.needShowError,
-            occursError: viewModel.occursError
+        .modifier(
+            HandleError(
+                needShowError: $viewModel.needShowError,
+                occursError: viewModel.occursError
+            )
         )
         .task {
             await viewModel.fetchRepository()
@@ -48,10 +50,13 @@ struct ContentView: View {
     }
 }
 
-fileprivate extension View {
-    func handleError(needShowError: Binding<Bool>,
-                     occursError: ContentViewModelError?) -> some View {
-        return alert(
+private struct HandleError: ViewModifier {
+    
+    let needShowError: Binding<Bool>
+    let occursError: ContentViewModelError?
+    
+    func body(content: Content) -> some View {
+        content.alert(
             isPresented: needShowError,
             error: occursError,
             actions: {


### PR DESCRIPTION
Modifierを指定することで対応しました。

また、サジェストや先頭大文字化もdisableに変更。
およびViewModifierに切り出す方法を使えたので、以前にextensionで実装したhandlerErrorもリファクタリング。

---
close #25