### PR TITLE
swift-tools-versionを6.0に、platformsをiOS 17に更新

### DIFF
--- a/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
+++ b/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FBD6FC3427B3A092005E3EA4"
+               BuildableName = "GitHubRepoBrowser.app"
+               BlueprintName = "GitHubRepoBrowser"
+               ReferencedContainer = "container:GitHubRepoBrowser.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FBD6FC4E27B3A093005E3EA4"
+               BuildableName = "GitHubRepoBrowserUITests.xctest"
+               BlueprintName = "GitHubRepoBrowserUITests"
+               ReferencedContainer = "container:GitHubRepoBrowser.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      region = "IS"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FBD6FC3427B3A092005E3EA4"
+            BuildableName = "GitHubRepoBrowser.app"
+            BlueprintName = "GitHubRepoBrowser"
+            ReferencedContainer = "container:GitHubRepoBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FBD6FC3427B3A092005E3EA4"
+            BuildableName = "GitHubRepoBrowser.app"
+            BlueprintName = "GitHubRepoBrowser"
+            ReferencedContainer = "container:GitHubRepoBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Model/Package.swift
+++ b/Model/Package.swift
@@ -1,29 +1,24 @@
-// swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:6.0
 
 import PackageDescription
 
 let package = Package(
     name: "Model",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v17)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Model",
             targets: ["Model"])
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Model",
-            dependencies: []),
+            dependencies: [],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
         .testTarget(
             name: "ModelTests",
-            dependencies: ["Model"])
+            dependencies: ["Model"],
+            swiftSettings: [.swiftLanguageMode(.v5)])
     ]
 )

--- a/ViewModel/Package.swift
+++ b/ViewModel/Package.swift
@@ -1,30 +1,26 @@
-// swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:6.0
 
 import PackageDescription
 
 let package = Package(
     name: "ViewModel",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v17)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ViewModel",
             targets: ["ViewModel"])
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(path: "../Model")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "ViewModel",
-            dependencies: ["Model"]),
+            dependencies: ["Model"],
+            swiftSettings: [.swiftLanguageMode(.v5)]),
         .testTarget(
             name: "ViewModelTests",
-            dependencies: ["ViewModel"])
+            dependencies: ["ViewModel"],
+            swiftSettings: [.swiftLanguageMode(.v5)])
     ]
 )


### PR DESCRIPTION
## Summary
- Model/ViewModel両パッケージの `swift-tools-version` を 5.5 → 6.0 に更新
- `platforms` を iOS 15 → iOS 17 に引き上げ
- Swift 6 の strict concurrency は段階的に対応するため `swiftLanguageMode(.v5)` を明示指定
- テンプレートコメントを削除

## 目的
後続のモダンSwiftUI化（`@Observable`、`NavigationStack`、`#Preview` 等）に向けた準備。

## Test plan
- [x] ビルド成功を確認
- [x] UITests 3件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)