### PR TITLE
XCTestをSwift Testing frameworkに移行

### DIFF
--- a/Model/Tests/ModelTests/ModelTests.swift
+++ b/Model/Tests/ModelTests/ModelTests.swift
@@ -1,62 +1,51 @@
-import XCTest
+import Testing
+import Foundation
 @testable import Model
 
-final class GitHubAPIClientTest: XCTestCase {
-    
-    private var client: GitHubAPIClient!
-    
-    override func setUp() {
+struct GitHubAPIClientTests {
+
+    private func makeClient() -> GitHubAPIClient {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         let session = URLSession(configuration: config)
-        self.client = GitHubAPIClient(urlSession: session)
+        return GitHubAPIClient(urlSession: session)
     }
-    
-    override func tearDown() {
-        MockURLProtocol.requestHandler = nil
-    }
-    
-    func testSuccess() async throws {
+
+    @Test("正常系：通信に成功してデータを返す")
+    func success() async throws {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!,
              testData.data(using: .utf8)!)
         }
-        
-        let result = try await self.client.fetchRepositories(userName: "test")
-        XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result.first!.name, "RxSwift")
+
+        let client = makeClient()
+        let result = try await client.fetchRepositories(userName: "test")
+        #expect(result.count == 1)
+        #expect(result.first?.name == "RxSwift")
     }
-    
-    // 通信エラーの場合
-    func testFailureConnection() async throws {
+
+    @Test("通信エラーの場合")
+    func failureConnection() async throws {
         MockURLProtocol.requestHandler = { _ in
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: nil)
         }
-        
-        do {
-            _ = try await self.client.fetchRepositories(userName: "test")
-            XCTFail("例外が発生すること")
-        } catch let error as GitHubAPIError {
-            XCTAssertEqual(error, GitHubAPIError.connectionError)
-        } catch {
-            XCTFail("GitHubAPIError型のエラーが発生すること")
+
+        let client = makeClient()
+        await #expect(throws: GitHubAPIError.connectionError) {
+            try await client.fetchRepositories(userName: "test")
         }
     }
-    
-    // JSONが不正な場合
-    func testBrokenJson() async throws {
+
+    @Test("JSONが不正な場合")
+    func brokenJson() async throws {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!,
              "]invalid json[".data(using: .utf8)!)
         }
-        
-        do {
-            _ = try await self.client.fetchRepositories(userName: "test")
-            XCTFail("例外が発生すること")
-        } catch let error as GitHubAPIError {
-            XCTAssertEqual(error, GitHubAPIError.jsonParseError)
-        } catch {
-            XCTFail("GitHubAPIError型のエラーが発生すること")
+
+        let client = makeClient()
+        await #expect(throws: GitHubAPIError.jsonParseError) {
+            try await client.fetchRepositories(userName: "test")
         }
     }
 }

--- a/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
+++ b/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
@@ -1,114 +1,113 @@
-import XCTest
+import Testing
 import Model
 @testable import ViewModel
 
 @MainActor
-final class ContentViewModelTests: XCTestCase {
-    
-    func testNormal() async throws {
-        // 正常系：通信に成功してデータを返す
+struct ContentViewModelTests {
+
+    @Test("正常系：通信に成功してデータを返す")
+    func normal() async throws {
         let apiClient = MockAPIClient(expectResult: Array(dummyRepositoryData[...0]))
         let navigator = MockNavigator()
         let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
-        
+
         // 初期状態（エラー、ロード表示なし）
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
-        
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+
         // ロードを実行中
         async let result: () = viewModel.fetchRepository()
         await Task.yield()
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertTrue(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
-        
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == true)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+
         // ロードを止めて結果を返す
         apiClient.resume()
         await result
-        XCTAssertEqual(viewModel.repositories.count, 1)
-        XCTAssertEqual(viewModel.repositories.first!.name, "テストデータ1")
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
+        #expect(viewModel.repositories.count == 1)
+        #expect(viewModel.repositories.first?.name == "テストデータ1")
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
     }
-    
-    func testFailure() async throws {
-        // 異常系：通信に失敗してアラートを表示する
+
+    @Test("異常系：通信に失敗してアラートを表示する")
+    func failure() async throws {
         let apiClient = MockAPIClient(expectError: .connectionError)
         let navigator = MockNavigator()
         let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
-        
+
         // 初期状態（エラー、ロード表示なし）
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
-        
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+
         // ロードを実行中
         async let result: () = viewModel.fetchRepository()
         await Task.yield()
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertTrue(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
-        
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == true)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+
         // ロードを止めて結果を返す
         apiClient.resume()
         await result
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertTrue(viewModel.needShowError)
-        XCTAssertEqual(viewModel.occursError, .responseError)
-        
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == true)
+        #expect(viewModel.occursError == .responseError)
+
         // アラートを閉じると初期状態に戻る
         viewModel.needShowError = false
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
     }
-    
-    func testEmptyInput() async throws {
-        // 入力が空のため何も実行しない
+
+    @Test("入力が空のため何も実行しない")
+    func emptyInput() async throws {
         let apiClient = MockAPIClient(expectResult: Array(dummyRepositoryData[...0]))
         let navigator = MockNavigator()
         let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
-        
+
         // 初期状態（エラー、ロード表示なし）
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
-        
-        XCTAssertFalse(viewModel.isQueryEmpty)
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+
+        #expect(viewModel.isQueryEmpty == false)
         viewModel.query = ""
-        XCTAssertTrue(viewModel.isQueryEmpty)
-        
+        #expect(viewModel.isQueryEmpty == true)
+
         // ロードを実行
         await viewModel.fetchRepository()
-        
+
         // 初期状態と同じであること
-        XCTAssertEqual(viewModel.repositories, [])
-        XCTAssertFalse(viewModel.showProgress)
-        XCTAssertFalse(viewModel.needShowError)
-        XCTAssertNil(viewModel.occursError)
+        #expect(viewModel.repositories == [])
+        #expect(viewModel.showProgress == false)
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
     }
 
-    func testTransition() {
-        // 画面遷移のテスト
+    @Test("画面遷移のテスト")
+    func transition() {
         let apiClient = MockAPIClient(expectResult: [])
         let navigator = MockNavigator()
         let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
-        
-        XCTAssertFalse(navigator.called)
+
+        #expect(navigator.called == false)
         viewModel.openBrowser(item: dummyRepositoryData[2])
-        XCTAssertTrue(navigator.called)
-        XCTAssertEqual(navigator.capturedUrl, dummyRepositoryData[2].htmlURL)
+        #expect(navigator.called == true)
+        #expect(navigator.capturedUrl == dummyRepositoryData[2].htmlURL)
     }
-    
 }
 
 private let dummyRepositoryData: [GitHubRepository] = {


### PR DESCRIPTION
## Summary
- `XCTestCase` → `struct` + `@Test` マクロ
- `XCTAssertEqual` / `XCTAssertTrue` / `XCTAssertFalse` / `XCTAssertNil` → `#expect`
- `XCTFail` + `do/catch` → `#expect(throws:)`
- `setUp` / `tearDown` → ファクトリメソッドに置き換え
- テストに日本語の説明文を追加

## Test plan
- [x] ビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)