### PR TITLE
Swift 6 strict concurrency対応

### DIFF
--- a/GitHubRepoBrowser.xcodeproj/project.pbxproj
+++ b/GitHubRepoBrowser.xcodeproj/project.pbxproj
@@ -119,7 +119,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FBD6FC5927B3A093005E3EA4 /* Build configuration list for PBXNativeTarget "GitHubRepoBrowser" */;
 			buildPhases = (
-				FB28C78827BF27CC0045C76F /* SwiftLint */,
 				FBD6FC3127B3A092005E3EA4 /* Sources */,
 				FBD6FC3227B3A092005E3EA4 /* Frameworks */,
 				FBD6FC3327B3A092005E3EA4 /* Resources */,
@@ -127,6 +126,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FB272FF42F5D3D410087032B /* PBXTargetDependency */,
 			);
 			name = GitHubRepoBrowser;
 			packageProductDependencies = (
@@ -163,7 +163,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					FBD6FC3427B3A092005E3EA4 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -184,6 +184,7 @@
 			);
 			mainGroup = FBD6FC2C27B3A092005E3EA4;
 			packageReferences = (
+				FB272FF22F5D3D210087032B /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = FBD6FC3627B3A092005E3EA4 /* Products */;
 			projectDirPath = "";
@@ -214,27 +215,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		FB28C78827BF27CC0045C76F /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nexport PATH=\"$PATH:/opt/homebrew/bin\"\nif which mint >/dev/null; then\n  mint run swiftlint swiftlint\nelse\n  echo \"warning: Mint not installed, download from https://github.com/yonaskolb/Mint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		FBD6FC3127B3A092005E3EA4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -257,6 +237,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		FB272FF42F5D3D410087032B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = FB272FF32F5D3D410087032B /* SwiftLintBuildToolPlugin */;
+		};
 		FBD6FC5127B3A093005E3EA4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FBD6FC3427B3A092005E3EA4 /* GitHubRepoBrowser */;
@@ -302,6 +286,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -321,6 +306,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -363,6 +349,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -375,6 +362,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
@@ -503,7 +491,23 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		FB272FF22F5D3D210087032B /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.63.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		FB272FF32F5D3D410087032B /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FB272FF22F5D3D210087032B /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
 		FB45334327BB2DA00053A4F0 /* Model */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Model;

--- a/GitHubRepoBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitHubRepoBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,96 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Swinject",
-        "repositoryURL": "https://github.com/Swinject/Swinject.git",
-        "state": {
-          "branch": null,
-          "revision": "f10b6e9ebff440f985c43008f7c2d097639fcb81",
-          "version": "2.8.1"
-        }
+  "originHash" : "c3373633343d643cf4275c42d63c44d7be89c54076117a694350d515b60c2b83",
+  "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
+        "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "731ffe6a35344a19bab00cdca1c952d5b4fee4d8",
+        "version" : "0.37.2"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-filename-matcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ileitch/swift-filename-matcher",
+      "state" : {
+        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
+        "version" : "604.0.0-prerelease-2026-01-20"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
+        "version" : "0.63.2"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
+++ b/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
+++ b/GitHubRepoBrowser.xcodeproj/xcshareddata/xcschemes/GitHubRepoBrowser.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:GitHubRepoBrowser.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ViewModelTests"
+               BuildableName = "ViewModelTests"
+               BlueprintName = "ViewModelTests"
+               ReferencedContainer = "container:ViewModel">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/GitHubRepoBrowser.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitHubRepoBrowser.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,96 @@
+{
+  "originHash" : "37514c4388e2bcfe688487977bbea33a28b34c1cccf5bf42a4db585782d6b34d",
+  "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
+        "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "731ffe6a35344a19bab00cdca1c952d5b4fee4d8",
+        "version" : "0.37.2"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-filename-matcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ileitch/swift-filename-matcher",
+      "state" : {
+        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
+        "version" : "604.0.0-prerelease-2026-01-20"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
+        "version" : "0.63.2"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Model/Package.swift
+++ b/Model/Package.swift
@@ -14,11 +14,9 @@ let package = Package(
     targets: [
         .target(
             name: "Model",
-            dependencies: [],
-            swiftSettings: [.swiftLanguageMode(.v5)]),
+            dependencies: []),
         .testTarget(
             name: "ModelTests",
-            dependencies: ["Model"],
-            swiftSettings: [.swiftLanguageMode(.v5)])
+            dependencies: ["Model"])
     ]
 )

--- a/Model/Sources/Model/GitHubAPIClient.swift
+++ b/Model/Sources/Model/GitHubAPIClient.swift
@@ -14,21 +14,21 @@ public enum GitHubAPIError: Error {
 }
 
 public final class GitHubAPIClient: GitHubAPIClientProtocol {
-
-    private let urlSession: URLSession
-
-    public init(urlSession: URLSession = URLSession.shared) {
-        self.urlSession = urlSession
+    
+    private let httpClient: HTTPClient
+    
+    public init(httpClient: HTTPClient = URLSessionHTTPClient(URLSession.shared)) {
+        self.httpClient = httpClient
     }
-
+    
     public func fetchRepositories(userName: String) async throws -> [GitHubRepository] {
         let url = try buildURL(userName: userName)
         let data = try await connection(url: url)
         let result = try parseResult(data: data)
-
+        
         return result
     }
-
+    
     private func buildURL(userName: String) throws -> URL {
         guard
             let userName = userName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
@@ -36,23 +36,23 @@ public final class GitHubAPIClient: GitHubAPIClientProtocol {
         else {
             throw GitHubAPIError.invalidURL
         }
-
+        
         return url
     }
-
+    
     private func connection(url: URL) async throws -> Data {
         do {
-            let (data, _) = try await self.urlSession.data(from: url)
+            let (data, _) = try await self.httpClient.data(from: url)
             return data
         } catch {
             throw GitHubAPIError.connectionError
         }
     }
-
+    
     private func parseResult(data: Data) throws -> [GitHubRepository] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-
+        
         do {
             return try decoder.decode([GitHubRepository].self, from: data)
         } catch {

--- a/Model/Sources/Model/GitHubAPIClientProtocol.swift
+++ b/Model/Sources/Model/GitHubAPIClientProtocol.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol GitHubAPIClientProtocol {
+public protocol GitHubAPIClientProtocol: Sendable {
 
     func fetchRepositories(userName: String) async throws -> [GitHubRepository]
 }

--- a/Model/Sources/Model/GitHubRepository.swift
+++ b/Model/Sources/Model/GitHubRepository.swift
@@ -28,6 +28,8 @@ public struct GitHubRepository {
 
 extension GitHubRepository: Equatable { }
 
+extension GitHubRepository: Sendable { }
+
 extension GitHubRepository: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Model/Sources/Model/HttpClient.swift
+++ b/Model/Sources/Model/HttpClient.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol HTTPClient: Sendable {
+    func data(from url: URL) async throws -> (Data, URLResponse)
+    
+    func data(for: URLRequest) async throws -> (Data, URLResponse)
+}

--- a/Model/Sources/Model/URLSessionHTTPClient.swift
+++ b/Model/Sources/Model/URLSessionHTTPClient.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+final public class URLSessionHTTPClient: HTTPClient {
+    
+    private let urlSession: URLSession
+    
+    public init(_ urlSession: URLSession) {
+        self.urlSession = urlSession
+    }
+    
+    public func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await self.urlSession.data(from: url)
+    }
+    
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.urlSession.data(for: request)
+    }
+}

--- a/Model/Tests/ModelTests/ModelTests.swift
+++ b/Model/Tests/ModelTests/ModelTests.swift
@@ -3,85 +3,66 @@ import Foundation
 @testable import Model
 
 struct GitHubAPIClientTests {
-
-    private func makeClient() -> GitHubAPIClient {
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
-        let session = URLSession(configuration: config)
-        return GitHubAPIClient(urlSession: session)
+    
+    private func makeClient(
+        handler: @escaping (@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse))
+    ) -> GitHubAPIClient {
+        return GitHubAPIClient(httpClient: MockHTTPClient(handler: handler))
     }
-
+    
     @Test("正常系：通信に成功してデータを返す")
     func success() async throws {
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!,
-             testData.data(using: .utf8)!)
+        let client = makeClient { request in
+            (testData.data(using: .utf8)!, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!)
         }
-
-        let client = makeClient()
         let result = try await client.fetchRepositories(userName: "test")
         #expect(result.count == 1)
         #expect(result.first?.name == "RxSwift")
     }
-
+    
     @Test("通信エラーの場合")
     func failureConnection() async throws {
-        MockURLProtocol.requestHandler = { _ in
+        let client = makeClient { _ in
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: nil)
         }
-
-        let client = makeClient()
         await #expect(throws: GitHubAPIError.connectionError) {
             try await client.fetchRepositories(userName: "test")
         }
     }
-
+    
     @Test("JSONが不正な場合")
     func brokenJson() async throws {
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!,
-             "]invalid json[".data(using: .utf8)!)
+        let client = makeClient { request in
+            ("]invalid json[".data(using: .utf8)!, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "2.0", headerFields: nil)!)
         }
-
-        let client = makeClient()
         await #expect(throws: GitHubAPIError.jsonParseError) {
             try await client.fetchRepositories(userName: "test")
         }
     }
 }
 
+private actor MockURLProtocolStorage {
+    var handler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+}
+
 // 通信テスト用のモック
-private class MockURLProtocol: URLProtocol {
+private final class MockHTTPClient: HTTPClient {
     
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    let handler: (@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse))
     
-    override class func canInit(with request: URLRequest) -> Bool {
-        return true
+    init(handler: @Sendable @escaping (URLRequest) async throws -> (Data, HTTPURLResponse)) {
+        self.handler = handler
     }
     
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await self.handler(URLRequest(url: url))
     }
     
-    override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
-            fatalError()
-        }
-        
-        do {
-            let (response, data)  = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-    
-    override func stopLoading() {
-        // for canceled.
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.handler(request)
     }
 }
+
 
 private let testData = """
 [

--- a/Model/Tests/ModelTests/ModelTests.swift
+++ b/Model/Tests/ModelTests/ModelTests.swift
@@ -41,10 +41,6 @@ struct GitHubAPIClientTests {
     }
 }
 
-private actor MockURLProtocolStorage {
-    var handler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
-}
-
 // 通信テスト用のモック
 private final class MockHTTPClient: HTTPClient {
     

--- a/ViewModel/Package.swift
+++ b/ViewModel/Package.swift
@@ -16,11 +16,9 @@ let package = Package(
     targets: [
         .target(
             name: "ViewModel",
-            dependencies: ["Model"],
-            swiftSettings: [.swiftLanguageMode(.v5)]),
+            dependencies: ["Model"]),
         .testTarget(
             name: "ViewModelTests",
-            dependencies: ["ViewModel"],
-            swiftSettings: [.swiftLanguageMode(.v5)])
+            dependencies: ["ViewModel"])
     ]
 )

--- a/ViewModel/Sources/ViewModel/ContentViewModel.swift
+++ b/ViewModel/Sources/ViewModel/ContentViewModel.swift
@@ -88,6 +88,8 @@ public class ContentViewModel {
             case .connectionError, .jsonParseError:
                 self.state = .failed(.responseError)
             }
+        } catch is CancellationError {
+            // タスクがキャンセルされた場合は何もしない
         } catch {
             fatalError("unknown error")
         }

--- a/ViewModel/Sources/ViewModel/ContentViewModel.swift
+++ b/ViewModel/Sources/ViewModel/ContentViewModel.swift
@@ -12,9 +12,9 @@ import Model
 @MainActor
 @Observable
 public class ContentViewModel {
-
+    
     private var state: ContentViewModelState = .idle
-
+    
     /// 読込中表示
     public var showProgress: Bool {
         switch self.state {
@@ -22,7 +22,7 @@ public class ContentViewModel {
         case .idle, .loaded, .failed: return false
         }
     }
-
+    
     /// 読み込んだリポジトリ
     public var repositories: [GitHubRepository] {
         switch self.state {
@@ -30,7 +30,7 @@ public class ContentViewModel {
         case .loaded(let newData): return newData
         }
     }
-
+    
     /// エラーアラートを表示するかどうか
     public var needShowError: Bool {
         get {
@@ -46,7 +46,7 @@ public class ContentViewModel {
             }
         }
     }
-
+    
     /// 発生したエラー
     public var occursError: ContentViewModelError? {
         switch self.state {
@@ -57,15 +57,15 @@ public class ContentViewModel {
     
     /// 検索するリポジトリ名
     public var query: String = "quesera2"
-
+    
     ///  リポジトリ名入力があるかどうか
     public var isQueryEmpty: Bool {
         query.isEmpty
     }
-
+    
     private let apiClient: GitHubAPIClientProtocol
     private let navigator: NavigatorProtocol
-
+    
     public init(
         apiClient: GitHubAPIClientProtocol = GitHubAPIClient(),
         navigator: NavigatorProtocol
@@ -73,13 +73,13 @@ public class ContentViewModel {
         self.apiClient = apiClient
         self.navigator = navigator
     }
-
+    
     public func fetchRepository() async {
         guard !self.isQueryEmpty else { return }
         
         self.state = .loading
         do {
-            let result = try await apiClient.fetchRepositories(userName: self.query)
+            let result = try await self.apiClient.fetchRepositories(userName: self.query)
             self.state = .loaded(result)
         } catch let error as GitHubAPIError {
             switch error {
@@ -92,7 +92,7 @@ public class ContentViewModel {
             fatalError("unknown error")
         }
     }
-
+    
     public func openBrowser(item: GitHubRepository) {
         navigator.openUrl(item.htmlURL)
     }

--- a/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
+++ b/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Model
+import Foundation
 @testable import ViewModel
 
 @MainActor
@@ -123,28 +124,31 @@ private let dummyRepositoryData: [GitHubRepository] = {
     }
 }()
 
-fileprivate final class MockAPIClient: GitHubAPIClientProtocol {
+fileprivate final class MockAPIClient: GitHubAPIClientProtocol, @unchecked Sendable {
 
     private let expectResult: [GitHubRepository]?
     private let expectError: GitHubAPIError?
 
-    private var continuation: CheckedContinuation<[GitHubRepository], Error>!
+    private var continuation: CheckedContinuation<[GitHubRepository], Error>?
+    private let continuationReady = DispatchSemaphore(value: 0)
 
     init(expectResult: [GitHubRepository]? = nil, expectError: GitHubAPIError? = nil) {
         self.expectResult = expectResult
         self.expectError = expectError
     }
 
-    func fetchRepositories(userName: String) async throws -> [GitHubRepository] {
+    nonisolated func fetchRepositories(userName: String) async throws -> [GitHubRepository] {
         return try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
+            self.continuationReady.signal()
         }
     }
-    
+
     func resume() {
+        continuationReady.wait()
         switch (expectResult, expectError) {
-        case (let expectResult?, nil): self.continuation.resume(returning: expectResult)
-        case (nil, let expectError?): self.continuation.resume(throwing: expectError)
+        case (let expectResult?, nil): self.continuation!.resume(returning: expectResult)
+        case (nil, let expectError?): self.continuation!.resume(throwing: expectError)
         default: fatalError()
         }
     }

--- a/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
+++ b/ViewModel/Tests/ViewModelTests/ContentViewModelTests.swift
@@ -98,6 +98,28 @@ struct ContentViewModelTests {
         #expect(viewModel.occursError == nil)
     }
 
+    @Test("タスクキャンセル時にクラッシュしない")
+    func cancellation() async throws {
+        let apiClient = MockAPIClient(expectResult: Array(dummyRepositoryData[...0]))
+        let navigator = MockNavigator()
+        let viewModel = ContentViewModel(apiClient: apiClient, navigator: navigator)
+
+        // ロードを開始
+        let task = Task { @MainActor in
+            await viewModel.fetchRepository()
+        }
+        await Task.yield()
+        #expect(viewModel.showProgress == true)
+
+        // タスクをキャンセル
+        task.cancel()
+        await task.value
+
+        // fatalErrorせずに完了すること（loading状態のまま残る）
+        #expect(viewModel.needShowError == false)
+        #expect(viewModel.occursError == nil)
+    }
+
     @Test("画面遷移のテスト")
     func transition() {
         let apiClient = MockAPIClient(expectResult: [])
@@ -138,9 +160,14 @@ fileprivate final class MockAPIClient: GitHubAPIClientProtocol, @unchecked Senda
     }
 
     nonisolated func fetchRepositories(userName: String) async throws -> [GitHubRepository] {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-            self.continuationReady.signal()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                self.continuationReady.signal()
+            }
+        } onCancel: {
+            self.continuationReady.wait()
+            self.continuation?.resume(throwing: CancellationError())
         }
     }
 


### PR DESCRIPTION
## Summary
- `swiftLanguageMode(.v5)` を削除し、Swift 6 strict concurrency を有効化
- `GitHubAPIClientProtocol` に `Sendable` 準拠を追加
- `URLSession` を直接使用せず `HTTPClient` プロトコルに抽象化し、`Sendable` に準拠
- `GitHubRepository` に `Sendable` 準拠を追加
- `ContentViewModel.fetchRepository()` で `CancellationError` を安全にハンドリング
- ModelTests を `MockURLProtocol` から `MockHTTPClient` ベースに書き換え
- ViewModelTests の `MockAPIClient` を `@unchecked Sendable` + `nonisolated` + `DispatchSemaphore` で strict concurrency 対応
- タスクキャンセル時のテストケースを追加

## Test plan
- [x] ModelTests (3件) パス
- [x] ViewModelTests (5件) パス
  - 正常系、異常系、空入力、画面遷移、タスクキャンセル

🤖 Generated with [Claude Code](https://claude.com/claude-code)