### PR TITLE
リポジトリ一覧画面のデザインをモダン化

### DIFF
--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -36,17 +36,34 @@ struct ContentView: View {
                     GitHubRepositoryView(item: item) {
                         viewModel.openBrowser(item: $0)
                     }
+                    .listRowSeparator(.visible)
                 }
             }
-            .navigationTitle("リポジトリ一覧")
+            .listStyle(.plain)
+            .navigationTitle(viewModel.repositories.isEmpty
+                ? "リポジトリ一覧"
+                : "リポジトリ一覧（\(viewModel.repositories.count)件）"
+            )
             .refreshable {
                 await viewModel.fetchRepository()
             }
             .overlay {
                 if viewModel.showProgress {
                     ProgressView()
+                } else if viewModel.hasLoaded && viewModel.repositories.isEmpty {
+                    ContentUnavailableView(
+                        "リポジトリが見つかりません",
+                        systemImage: "folder",
+                        description: Text("このユーザーにはリポジトリがありません")
+                    )
                 }
             }
+            .modifier(RepositorySearch(
+                query: $viewModel.query,
+                action: {
+                    await viewModel.fetchRepository()
+                })
+            )
         }
         .alert(
             isPresented: $viewModel.needShowError,
@@ -58,12 +75,6 @@ struct ContentView: View {
         .task {
             await viewModel.fetchRepository()
         }
-        .modifier(RepositorySearch(
-            query: $viewModel.query,
-            action: {
-                await viewModel.fetchRepository()
-            })
-        )
     }
 }
 
@@ -77,7 +88,7 @@ private struct RepositorySearch: ViewModifier {
             text: $query,
             prompt: "ユーザー名を入力してください")
             .keyboardType(.alphabet)
-            .disableAutocorrection(true)
+            .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .onSubmit(of: .search) {
                 Task {

--- a/GitHubRepoBrowser/GitHubRepositoryView.swift
+++ b/GitHubRepoBrowser/GitHubRepositoryView.swift
@@ -10,47 +10,79 @@ import SwiftUI
 import Model
 
 struct GitHubRepositoryView: View {
-    
+
     let item: GitHubRepository
-    
+
     let action: (GitHubRepository) -> Void
-    
+
     var body: some View {
-        Button(
-            action: {
-                self.action(item)
-            }, label: {
-                VStack(alignment: .leading, spacing: 5) {
-                    Text(item.name)
-                        .font(.title2)
-                        .foregroundColor(.primary)
-                    if !item.description.isEmpty {
-                        Text(item.description)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+        Button {
+            self.action(item)
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(item.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+
+                if !item.description.isEmpty {
+                    Text(item.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
                 }
-                .frame(
-                    minWidth: 0,
-                    maxWidth: .infinity,
-                    minHeight: 44,
-                    alignment: .topLeading
-                )
-                .padding([.leading, .trailing], 10)
-                .padding([.top, .bottom], 5)
+
+                HStack(spacing: 16) {
+                    if let language = item.language {
+                        Label(language, systemImage: "chevron.left.forwardslash.chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Label {
+                        Text(item.stargazersCount, format: .number)
+                            .font(.caption)
+                    } icon: {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(.yellow)
+                            .font(.caption)
+                    }
+                    .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Text(item.updatedAt, format: .relative(presentation: .named))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
             }
-        )
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
     }
 }
 
 #Preview {
-    GitHubRepositoryView(
-        item: GitHubRepository(id: 1,
-                               name: "テストデータ",
-                               htmlURL: URL(string: "http://google.com")!,
-                               description: "説明テキスト",
-                               createdAt: Date(),
-                               updatedAt: Date()),
-        action: { _ in }
-    )
+    List {
+        GitHubRepositoryView(
+            item: GitHubRepository(id: 1,
+                                   name: "swift-composable-architecture",
+                                   htmlURL: URL(string: "http://example.com")!,
+                                   description: "A library for building applications in a consistent and understandable way.",
+                                   stargazersCount: 12300,
+                                   language: "Swift",
+                                   createdAt: Date(),
+                                   updatedAt: Date().addingTimeInterval(-86400)),
+            action: { _ in }
+        )
+        GitHubRepositoryView(
+            item: GitHubRepository(id: 2,
+                                   name: "my-project",
+                                   htmlURL: URL(string: "http://example.com")!,
+                                   description: "",
+                                   stargazersCount: 0,
+                                   createdAt: Date(),
+                                   updatedAt: Date()),
+            action: { _ in }
+        )
+    }
 }

--- a/Model/Sources/Model/GitHubRepository.swift
+++ b/Model/Sources/Model/GitHubRepository.swift
@@ -13,14 +13,19 @@ public struct GitHubRepository {
     public let name: String
     public let htmlURL: URL
     public let description: String
+    public let stargazersCount: Int
+    public let language: String?
     public let createdAt, updatedAt: Date
 
     public init(id: Int, name: String, htmlURL: URL, description: String,
+                stargazersCount: Int = 0, language: String? = nil,
                 createdAt: Date, updatedAt: Date) {
         self.id = id
         self.name = name
         self.htmlURL = htmlURL
         self.description = description
+        self.stargazersCount = stargazersCount
+        self.language = language
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -36,6 +41,8 @@ extension GitHubRepository: Decodable {
         self.id = try container.decode(Int.self, forKey: CodingKeys.id)
         self.name = try container.decode(String.self, forKey: CodingKeys.name)
         self.description = try container.decode(String?.self, forKey: CodingKeys.description) ?? ""
+        self.stargazersCount = try container.decode(Int.self, forKey: CodingKeys.stargazersCount)
+        self.language = try container.decodeIfPresent(String.self, forKey: CodingKeys.language)
         let htmlURLString = try container.decode(String.self, forKey: CodingKeys.htmlURL)
         guard
             let htmlURL = URL(string: htmlURLString)
@@ -54,6 +61,8 @@ extension GitHubRepository: Decodable {
         case fullName = "full_name"
         case htmlURL = "html_url"
         case description
+        case stargazersCount = "stargazers_count"
+        case language
         case url
         case createdAt = "created_at"
         case updatedAt = "updated_at"

--- a/ViewModel/Sources/ViewModel/ContentViewModel.swift
+++ b/ViewModel/Sources/ViewModel/ContentViewModel.swift
@@ -31,6 +31,14 @@ public class ContentViewModel {
         }
     }
     
+    /// ロード済みかどうか（空の結果も含む）
+    public var hasLoaded: Bool {
+        switch self.state {
+        case .loaded: return true
+        case .idle, .loading, .failed: return false
+        }
+    }
+    
     /// エラーアラートを表示するかどうか
     public var needShowError: Bool {
         get {


### PR DESCRIPTION
- GitHubRepositoryにスター数・言語フィールドを追加
- GitHubRepositoryViewにスター数、言語、相対更新日時を表示
- ContentViewのリストスタイルをplainに変更し、空状態表示を追加
- ナビゲーションタイトルにリポジトリ件数を表示
- searchableをNavigationStack内に移動
- deprecated APIの置き換え (disableAutocorrection → autocorrectionDisabled)