### PR TITLE
リスト行のタップ判定と検索後のUI挙動を改善

### DIFF
--- a/GitHubRepoBrowser/ContentView.swift
+++ b/GitHubRepoBrowser/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentViewScreen: View {
 struct ContentView: View {
         
     @State private var viewModel: ContentViewModel
+    @State private var isSearchPresented = false
     
     init(navigator: NavigatorProtocol,
          apiClient: GitHubAPIClientProtocol) {
@@ -58,12 +59,19 @@ struct ContentView: View {
                     )
                 }
             }
-            .modifier(RepositorySearch(
-                query: $viewModel.query,
-                action: {
+            .searchable(
+                text: $viewModel.query,
+                isPresented: $isSearchPresented,
+                prompt: "ユーザー名を入力してください")
+            .keyboardType(.alphabet)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            .onSubmit(of: .search) {
+                Task {
                     await viewModel.fetchRepository()
-                })
-            )
+                    isSearchPresented = false
+                }
+            }
         }
         .alert(
             isPresented: $viewModel.needShowError,
@@ -76,27 +84,6 @@ struct ContentView: View {
             await viewModel.fetchRepository()
         }
     }
-}
-
-private struct RepositorySearch: ViewModifier {
-    
-    @Binding var query: String
-    let action: () async -> Void
-    
-    func body(content: Content) -> some View {
-        content.searchable(
-            text: $query,
-            prompt: "ユーザー名を入力してください")
-            .keyboardType(.alphabet)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
-            .onSubmit(of: .search) {
-                Task {
-                    await self.action()
-                }
-            }
-    }
-    
 }
 
 #Preview {

--- a/GitHubRepoBrowser/GitHubRepositoryView.swift
+++ b/GitHubRepoBrowser/GitHubRepositoryView.swift
@@ -56,6 +56,7 @@ struct GitHubRepositoryView: View {
                 }
             }
             .padding(.vertical, 4)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Summary
- GitHubRepositoryViewに`.contentShape(Rectangle())`を追加し、テキスト以外の余白部分もタップ可能に
- 検索実行後に`.searchable`の`isPresented`を`false`にして検索バーを閉じ、ナビゲーションタイトルを表示するように変更
- 不要になった`RepositorySearch` ViewModifierを削除してインライン化

## Test plan
- [x] リポジトリ一覧でテキストがない余白部分をタップしてブラウザが開くことを確認
- [x] 検索実行後にキャンセルボタンが消えてナビゲーションタイトルが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)